### PR TITLE
Requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/keboola/docker-custom-python:latest
 
 RUN pip install  --upgrade --no-cache-dir --ignore-installed pylooker
 
-#COPY /data/ /data/
+COPY /data/ /data/
 
 COPY . /code/
 WORKDIR /data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM quay.io/keboola/docker-custom-python:latest
 
-RUN pip install  --upgrade --no-cache-dir --ignore-installed pylooker
-
-COPY /data/ /data/
+#COPY /data/ /data/
 
 COPY . /code/
 WORKDIR /data/

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ import pprint
 import re
 from keboola import docker
 from pylooker.client import LookerClient
-
+import requests
 
 
 ### Environment setup

--- a/main.py
+++ b/main.py
@@ -12,11 +12,9 @@ Python 3 environment
 import sys
 import os
 import logging
-import csv
-import json
 import pandas as pd
-import pprint
 import requests
+import json
 import re
 from keboola import docker
 
@@ -30,7 +28,7 @@ sys.tracebacklimit = 0
 
 ### Logging
 logging.basicConfig(
-    level=logging.DEBUG,
+    level=logging.INFO,
     format='%(asctime)s - %(levelname)-8s : [line:%(lineno)3s] %(message)s',
     datefmt="%Y-%m-%d %H:%M:%S")
 

--- a/main.py
+++ b/main.py
@@ -9,11 +9,6 @@ Python 3 environment
 #import pip
 #pip.main(['install', '--disable-pip-version-check', '--no-cache-dir', 'logging_gelf'])
 
-
-########################
-####### NO PIVOT #######
-########################
-
 import sys
 import os
 import logging

--- a/main.py
+++ b/main.py
@@ -21,12 +21,11 @@ import csv
 import json
 import pandas as pd
 import pprint
+import requests
 import re
 from keboola import docker
-from pylooker.client import LookerClient
-import requests
 
-########## Limited to 5000 rows with pivot, otherwise no pivot is downloaded ########
+
 
 ### Environment setup
 abspath = os.path.abspath(__file__)
@@ -36,7 +35,7 @@ sys.tracebacklimit = 0
 
 ### Logging
 logging.basicConfig(
-    level=logging.INFO,
+    level=logging.DEBUG,
     format='%(asctime)s - %(levelname)-8s : [line:%(lineno)3s] %(message)s',
     datefmt="%Y-%m-%d %H:%M:%S")
 
@@ -47,7 +46,7 @@ client_id = params['client_id']
 client_secret = params['#client_secret']
 api_endpoint = params['api_endpoint']
 looker_objects = params['looker_objects']
-#data_table = cfg.get_parameters()["data_table"]
+
 
 #logging.debug("Fetched parameters are :" + str(params))
 
@@ -63,7 +62,43 @@ DEFAULT_FILE_INPUT = "/data/in/tables/"
 DEFAULT_FILE_DESTINATION = "/data/out/tables/"
 
 
-def create_manifest(file_name, destination):
+def fetch_data(endpoint, id, secret, object_id, limit):
+    """
+    Function fetching the data from query or looker via API.
+    """
+
+    logging.info("Attempting to access API endpoint %s" % endpoint)
+
+    params = {'client_id': id, 
+              'client_secret': secret}
+
+    logging.info("Logging in...")
+    login = requests.post(api_endpoint + 'login', params=params)
+
+    if login.status_code == 200:
+        logging.info("Login to Looker was successfull.")
+        token = login.json()['access_token']
+    else:
+        logging.error("Could not login to Looker. Please check, whether correct credentials and/or endpoint were inputted.")
+        logging.error("Server response: %s" % login.reason)
+        sys.exit(1)
+    
+    head = {'Authorization': 'token %s' % token}
+    look_url = endpoint + 'looks/%s/run/json?limit=%s' % (object_id, str(limit))
+
+    logging.info("Attempting to download data for look %s" % object_id)
+    data = requests.get(look_url, headers=head)
+
+    if data.status_code == 200:
+        logging.info("Data was downloaded successfully.")
+        return pd.io.json.json_normalize(data.json())
+    else: 
+        logging.error("Data could not be downloaded.")
+        logging.error("Request returned: Error %s %s" % (data.status_code, data.reason))
+        logging.warn("For more information, see: %s" % data.json()['documentation_url'])
+        sys.exit(1)
+
+def create_manifest(file_name, destination, primary_key, incremental):
     """
     Function for manifest creation.
     """
@@ -72,8 +107,8 @@ def create_manifest(file_name, destination):
 
     manifest_template = {
                          "destination": str(destination),
-                         "incremental": False,
-                         "primary_key": []
+                         "incremental": incremental,
+                         "primary_key": primary_key
                         }
 
     manifest = manifest_template
@@ -85,37 +120,6 @@ def create_manifest(file_name, destination):
     except Exception as e:
         logging.error("Could not produce %s output file manifest." % file_name)
         logging.error(e)
-
-def fetch_data(endpoint, id, secret, object_id):
-    """
-    Function fetching the data from query or looker via API.
-    """
-
-    logging.info("Attempting to access API endpoint %s" % endpoint)
-
-    lc = LookerClient(endpoint, id, secret)
-
-    
-    try:
-        look_data = lc.run_look(int(object_id))
-    except:
-        logging.error("Unable to download data. Please check whether API endpoint was inputted correctly.")
-        sys.exit(1)
-
-    if (isinstance(look_data, dict) and \
-    "message" in look_data.keys()):
-        log = "Data could not be downloaded. Response for look {} "\
-        "from server was: {}. Process exiting."
-
-        logging.error(log.format(id, look_data['message']))
-        logging.warn("Please make sure that look %s exists." % id)
-        sys.exit(1)
-    elif isinstance(look_data, list):
-        logging.info("Data for look %s was downloaded successfully." % object_id)
-        return pd.DataFrame(look_data)
-    else:
-        logging.error("Unexpected type. Expected dict or list, got %s" % type(look_data))
-        sys.exit(2)
 
 def fullmatch_re(pattern, string):
     match = re.fullmatch(pattern, string)
@@ -129,6 +133,7 @@ def main():
     for obj in looker_objects:
         id = obj['id']
         output = obj['output']
+
 
         bool = fullmatch_re(r'^(in|out)\.(c-)\w*\.[\w\-]*', output)
         
@@ -145,7 +150,7 @@ def main():
         file_name = 'looker_data_%s.csv' % id
         output_path = DEFAULT_FILE_DESTINATION + file_name
 
-        look_data = fetch_data(api_endpoint, client_id, client_secret, id)
+        look_data = fetch_data(api_endpoint, client_id, client_secret, id, 5000)
         look_data.to_csv(output_path, index=False)
         create_manifest(file_name, destination)
 

--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ from keboola import docker
 from pylooker.client import LookerClient
 import requests
 
+########## Limited to 5000 rows with pivot, otherwise no pivot is downloaded ########
 
 ### Environment setup
 abspath = os.path.abspath(__file__)

--- a/ui.json
+++ b/ui.json
@@ -1,68 +1,94 @@
 {
-    "title": "Parameters",
-    "type": "object",
-    "required": [
-      "client_id",
-      "#client_secret",
-      "api_endpoint",
-      "looker_objects"
-    ],
-    "properties": {
-      "client_id": {
-        "title": "Client ID",
-        "type": "string",
-        "description": "Client ID for API calls.",
-        "minLength": 1,
-        "default": "",
-        "propertyOrder": 1
-      },
-      "#client_secret": {
-        "type": "string",
-        "format": "password",
-        "title": "Client Secret",
-        "description": "Client secret for API calls.",
-        "minLength": 1,
-        "default": "",
-        "propertyOrder": 2
-      },
-      "api_endpoint": {
-        "type": "string",
-        "title": "API Endpoint.",
-        "description": "API endpoint for API calls. Usually in form 'https://company.looker.com:19999/api/3.0/'.",
-        "default": "https://company.looker.com:19999/api/3.0/",
-        "propertyOrder": 3
-      },
-      "looker_objects": {
-        "type": "array",
-        "format": "table",
-        "title": "Looker objects",
-        "uniqueItems": true,
-        "propertyOrder": 4,
-        "items": {
-          "type": "object",
-          "title": "Object",
-          "properties": {
-            "id": {
-              "type": "string",
-              "title": "Look ID",
-              "propertyOrder": 1,
-              "description": "ID of a look, from which the data is to be downloaded."
-            },
-            "output" : {
-              "type": "string",
-              "title": "Destination table",
-              "default": "",
-              "propertyOrder": 2,
-              "description": "Table destination in storage. If left blank, tables will be downloaded to in.c-looker.looker_data_xx, where xx is the ID of look."
-            }
+  "title": "Parameters",
+  "type": "object",
+  "required": [
+    "client_id",
+    "#client_secret",
+    "api_endpoint",
+    "looker_objects"
+  ],
+  "properties": {
+    "client_id": {
+      "title": "Client ID",
+      "type": "string",
+      "description": "Client ID for API calls.",
+      "minLength": 1,
+      "default": "",
+      "propertyOrder": 1
+    },
+    "#client_secret": {
+      "type": "string",
+      "format": "password",
+      "title": "Client Secret",
+      "description": "Client secret for API calls.",
+      "minLength": 1,
+      "default": "",
+      "propertyOrder": 2
+    },
+    "api_endpoint": {
+      "type": "string",
+      "title": "API Endpoint.",
+      "description": "API endpoint for API calls. Usually in form 'https://company.looker.com:19999/api/3.0/'.",
+      "default": "https://company.looker.com:19999/api/3.0/",
+      "propertyOrder": 3
+    },
+    "looker_objects": {
+      "type": "array",
+      "format": "table",
+      "title": "Looker objects",
+      "uniqueItems": true,
+      "propertyOrder": 4,
+      "items": {
+        "type": "object",
+        "title": "Object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Look ID",
+            "propertyOrder": 1,
+            "description": "ID of a look, from which the data is to be downloaded."
+          },
+          "output" : {
+            "type": "string",
+            "title": "Destination table",
+            "default": "",
+            "propertyOrder": 2,
+            "description": "Table destination in storage. If left blank, tables will be downloaded to in.c-looker.looker_data_xx, where xx is the ID of look."
+          },
+          "incremental" : {
+            "type": "boolean",
+            "enum": [
+              false,
+              true
+            ],
+            "propertyOrder": 3,
+            "default": false,
+            "title": "Incremental load",
+            "description": "Marks, whether table should be loaded incrementally into storage."
+          },
+          "primary_key": {
+            "type": "string",
+            "title": "Primary key",
+            "description": "Comma separated column names to be used as primary keys.",
+            "propertyOrder": 4
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit",
+            "description": "Limit of rows to be downloaded. See component description for information on limitations of Looker API.",
+            "propertyOrder": 5
           }
-        },
-        "default": [
-          {
-            "id": "1",
-            "output": ""
-          }
-        ]
-      }
+        }
+      },
+      "default": [
+        {
+          "id": "1",
+          "output": "",
+          "incremental": false,
+          "primary_key": "",
+          "limit": 5000
+        }
+      ]
     }
   }
+}


### PR DESCRIPTION
Changes to way data is downloaded via Looker API (now uses `requests` library instead of custom library before). Due to limitations of Looker API, all downloads with pivot columns are restricted to 5000 limits. This limit may be overwritten, but data dimensionality is reduced, i.e. all pivot columns and measures are omitted. The limitation does not apply to non-pivoted tables.